### PR TITLE
[STS-4592] Ensure renderViewState is only called when views are on screen.

### DIFF
--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleFragment.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleFragment.kt
@@ -1,0 +1,29 @@
+package com.coreyhorn.mvpiframeworkexample
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.coreyhorn.mvpiframework.architecture.PresenterFactory
+import com.coreyhorn.mvpiframework.architecture.PresenterFragment
+import kotlinx.android.synthetic.main.fragment_example.*
+
+class ExampleFragment: PresenterFragment<ExampleEvent, ExampleAction, ExampleResult, ExampleState>() {
+
+    override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater!!.inflate(R.layout.fragment_example, container, false)
+    }
+
+    override fun loaderId() = 2
+
+    override fun presenterFactory(): PresenterFactory<ExamplePresenter> = object: PresenterFactory<ExamplePresenter>() {
+        override fun create() = ExamplePresenter()
+    }
+
+    override fun renderViewState(state: ExampleState) {
+        fragmentText.text = "Whatever Test"
+    }
+
+    override fun setupViewBindings() {
+    }
+}

--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleInteractor.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleInteractor.kt
@@ -1,0 +1,11 @@
+package com.coreyhorn.mvpiframeworkexample
+
+import com.coreyhorn.mvpiframework.architecture.Interactor
+
+class ExampleInteractor: Interactor<ExampleResult>() {
+
+    init {
+        results.onNext(ExampleResult.TestResult())
+    }
+
+}

--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExamplePresenter.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExamplePresenter.kt
@@ -5,11 +5,20 @@ import io.reactivex.Observable
 
 class ExamplePresenter: Presenter<ExampleEvent, ExampleAction, ExampleResult, ExampleState>() {
 
-    override fun attachResultStream(results: Observable<ExampleResult>) {
+    init {
+        attachResultStream(ExampleInteractor().results())
+    }
 
+    override fun attachResultStream(results: Observable<ExampleResult>) {
+        results.scan(ExampleState("hmm"), this::accumulator)
+                .subscribe(states)
     }
 
     override fun attachEventStream(events: Observable<ExampleEvent>) {
         super.attachEventStream(events)
+    }
+
+    private fun accumulator(previousState: ExampleState, result: ExampleResult): ExampleState {
+        return ExampleState("hmm")
     }
 }

--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/MainActivity.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/MainActivity.kt
@@ -11,6 +11,14 @@ class MainActivity : PresenterActivity<ExampleEvent, ExampleAction, ExampleResul
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         events.onNext(ExampleEvent.TestEvent())
+
+        if (savedInstanceState == null) {
+
+            val fragment = ExampleFragment()
+
+            supportFragmentManager.beginTransaction().add(R.id.fragmentContainer, fragment)
+                    .commit()
+        }
     }
 
     //Should be a unique id

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
     tools:context="com.coreyhorn.mvpiframeworkexample.MainActivity">
 
     <TextView
+        android:id="@+id/text"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
         android:text="Hello World!"
@@ -14,5 +15,10 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/fragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_example.xml
+++ b/app/src/main/res/layout/fragment_example.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/fragmentText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="fragment text"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterActivity.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterActivity.kt
@@ -17,6 +17,7 @@ abstract class PresenterActivity<E : Event, A : Action, R : Result, S : State> :
     override var presenter: Presenter<E, A, R, S>? = null
     override var disposables = CompositeDisposable()
     override var attachAttempted = false
+    override var paused = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,11 +26,13 @@ abstract class PresenterActivity<E : Event, A : Action, R : Result, S : State> :
 
     override fun onResume() {
         super.onResume()
+        paused = false
         attachStream()
         setupViewBindings()
     }
 
     override fun onPause() {
+        paused = true
         detachStream()
         super.onPause()
     }

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterFragment.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterFragment.kt
@@ -17,6 +17,7 @@ abstract class PresenterFragment<E : Event, A : Action, R : Result, S : State> :
     override var presenter: Presenter<E, A, R, S>? = null
     override var disposables = CompositeDisposable()
     override var attachAttempted = false
+    override var paused = true
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
@@ -25,11 +26,13 @@ abstract class PresenterFragment<E : Event, A : Action, R : Result, S : State> :
 
     override fun onResume() {
         super.onResume()
-        attachStream()
+        paused = false
         setupViewBindings()
+        attachStream()
     }
 
     override fun onPause() {
+        paused = true
         detachStream()
         super.onPause()
     }

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterView.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterView.kt
@@ -24,6 +24,7 @@ interface PresenterView<E : Event, A : Action, R : Result, S : State> {
     var presenter: Presenter<E, A, R, S>?
     var disposables: CompositeDisposable
     var attachAttempted: Boolean
+    var paused: Boolean
 
     val loaderCallbacks: LoaderManager.LoaderCallbacks<Presenter<E, A, R, S>>
         get() = object : LoaderManager.LoaderCallbacks<Presenter<E, A, R, S>> {
@@ -58,7 +59,11 @@ interface PresenterView<E : Event, A : Action, R : Result, S : State> {
         presenter?.let {
             it.attachEventStream(events)
             it.states()
-                    .subscribe { renderViewStateOnMainThread(it) }
+                    .subscribe {
+                        if (!paused) {
+                            renderViewStateOnMainThread(it)
+                        }
+                    }
                     .disposeWith(disposables)
 
             events.doOnNext {


### PR DESCRIPTION
Flesh out example further
Fix issue with renderViewState being called when views are null


To test:
- Launch example app
- Immediately change orientation before the screen is loaded completely
- Notice a crash before this fix and none after