### PR TITLE
Rework attaching / detaching of streams. Pass view into render / binding calls

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '27.0.3'
+
     defaultConfig {
         applicationId "com.coreyhorn.mvpiframework"
         minSdkVersion 21
@@ -15,6 +15,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -26,13 +27,13 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation "io.reactivex.rxjava2:rxjava:2.1.9"
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "io.reactivex.rxjava2:rxjava:2.2.0"
 
     compile project(":mvpiframework")
 }

--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleFragment.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.coreyhorn.mvpiframework.architecture.PresenterFactory
 import com.coreyhorn.mvpiframework.architecture.PresenterFragment
-import kotlinx.android.synthetic.main.fragment_example.*
+import kotlinx.android.synthetic.main.fragment_example.view.*
 
 class ExampleFragment: PresenterFragment<ExampleEvent, ExampleAction, ExampleResult, ExampleState>() {
 
@@ -20,10 +20,11 @@ class ExampleFragment: PresenterFragment<ExampleEvent, ExampleAction, ExampleRes
         override fun create() = ExamplePresenter()
     }
 
-    override fun renderViewState(state: ExampleState) {
-        fragmentText.text = "Whatever Test"
+    override fun renderViewState(view: View, state: ExampleState) {
+        view.fragmentText.text = state.whatever
     }
 
-    override fun setupViewBindings() {
+    override fun setupViewBindings(view: View) {
+        view.changeText.setOnClickListener { events.onNext(ExampleEvent.TestEvent()) }
     }
 }

--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleInteractor.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExampleInteractor.kt
@@ -1,11 +1,12 @@
 package com.coreyhorn.mvpiframeworkexample
 
 import com.coreyhorn.mvpiframework.architecture.Interactor
+import io.reactivex.Observable
 
-class ExampleInteractor: Interactor<ExampleResult>() {
+class ExampleInteractor(actions: Observable<ExampleAction>): Interactor<ExampleResult>() {
 
     init {
-        results.onNext(ExampleResult.TestResult())
+        actions.map { ExampleResult.TestResult() }.subscribe(results)
     }
 
 }

--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExamplePresenter.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/ExamplePresenter.kt
@@ -2,11 +2,12 @@ package com.coreyhorn.mvpiframeworkexample
 
 import com.coreyhorn.mvpiframework.architecture.Presenter
 import io.reactivex.Observable
+import java.util.*
 
 class ExamplePresenter: Presenter<ExampleEvent, ExampleAction, ExampleResult, ExampleState>() {
 
     init {
-        attachResultStream(ExampleInteractor().results())
+        attachResultStream(ExampleInteractor(actions).results())
     }
 
     override fun attachResultStream(results: Observable<ExampleResult>) {
@@ -16,9 +17,11 @@ class ExamplePresenter: Presenter<ExampleEvent, ExampleAction, ExampleResult, Ex
 
     override fun attachEventStream(events: Observable<ExampleEvent>) {
         super.attachEventStream(events)
+
+        events.map { ExampleAction.TestAction() }.subscribe(actions)
     }
 
     private fun accumulator(previousState: ExampleState, result: ExampleResult): ExampleState {
-        return ExampleState("hmm")
+        return ExampleState(Date().time.toString())
     }
 }

--- a/app/src/main/java/com/coreyhorn/mvpiframeworkexample/MainActivity.kt
+++ b/app/src/main/java/com/coreyhorn/mvpiframeworkexample/MainActivity.kt
@@ -2,6 +2,8 @@ package com.coreyhorn.mvpiframeworkexample
 
 import android.content.Context
 import android.os.Bundle
+import android.view.View
+import com.coreyhorn.mvpiframework.MVPISettings
 import com.coreyhorn.mvpiframework.architecture.PresenterActivity
 import com.coreyhorn.mvpiframework.architecture.PresenterFactory
 
@@ -9,6 +11,7 @@ class MainActivity : PresenterActivity<ExampleEvent, ExampleAction, ExampleResul
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        MVPISettings.loggingEnabled = true
         setContentView(R.layout.activity_main)
         events.onNext(ExampleEvent.TestEvent())
 
@@ -30,11 +33,11 @@ class MainActivity : PresenterActivity<ExampleEvent, ExampleAction, ExampleResul
         override fun create() = ExamplePresenter()
     }
 
-    override fun renderViewState(state: ExampleState) {
+    override fun renderViewState(view: View, state: ExampleState) {
 
     }
 
-    override fun setupViewBindings() {
+    override fun setupViewBindings(view: View) {
 
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
-    android:layout_width="match_parent"
-    tools:context="com.coreyhorn.mvpiframeworkexample.MainActivity">
+    android:layout_width="match_parent">
 
     <TextView
         android:id="@+id/text"

--- a/app/src/main/res/layout/fragment_example.xml
+++ b/app/src/main/res/layout/fragment_example.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <TextView
@@ -7,5 +10,19 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="fragment text"/>
+
+    <Button
+        android:id="@+id/changeText"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_width="wrap_content"
+        android:text="Change Text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </android.support.constraint.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.10'
-    ext.kotlin_version = '1.1.60'
+    ext.kotlin_version = '1.2.51'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha07'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha13'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 18 13:41:55 EDT 2018
+#Thu Oct 04 17:27:34 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/mvpiframework/build.gradle
+++ b/mvpiframework/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '27.0.3'
-
 
     defaultConfig {
         minSdkVersion 21
@@ -22,7 +20,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {
@@ -35,9 +32,9 @@ dependencies {
 
     implementation "io.reactivex.rxjava2:rxjava:2.2.0"
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
+
 repositories {
     mavenCentral()
 }

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterActivity.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterActivity.kt
@@ -1,6 +1,7 @@
 package com.coreyhorn.mvpiframework.architecture
 
 import android.os.Bundle
+import android.os.PersistableBundle
 import android.support.v4.app.LoaderManager
 import android.support.v7.app.AppCompatActivity
 import android.view.View
@@ -35,15 +36,27 @@ abstract class PresenterActivity<E : Event, A : Action, R : Result, S : State> :
             override fun onGlobalLayout() {
                 view.viewTreeObserver.removeOnGlobalLayoutListener(this)
                 setView(view)
-                view.post {
-                    setupViewBindings(view)
-                }
             }
         })
     }
 
-    override fun onDestroy() {
+    override fun onResume() {
+        super.onResume()
+        attachStream()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle?, outPersistentState: PersistableBundle?) {
         detachStream()
+        super.onSaveInstanceState(outState, outPersistentState)
+    }
+
+    override fun onStop() {
+        detachStream()
+        super.onStop()
+    }
+
+    override fun onDestroy() {
+        rootView = null
         super.onDestroy()
     }
 

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterFragment.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.app.LoaderManager
 import android.view.View
+import android.view.ViewTreeObserver
 import com.coreyhorn.mvpiframework.basemodels.Action
 import com.coreyhorn.mvpiframework.basemodels.Event
 import com.coreyhorn.mvpiframework.basemodels.Result
@@ -27,19 +28,31 @@ abstract class PresenterFragment<E : Event, A : Action, R : Result, S : State> :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setView(view)
-        view.post {
-            setupViewBindings(view)
-        }
+        view.viewTreeObserver.addOnGlobalLayoutListener(object: ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                view.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                setView(view)
+            }
+        })
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onStart() {
+        super.onStart()
         attachStream()
     }
 
-    override fun onDestroy() {
+    override fun onResume() {
+        super.onResume()
+        attachStream()
+    }
+
+    override fun onStop() {
         detachStream()
+        super.onStop()
+    }
+
+    override fun onDestroy() {
+        rootView = null
         super.onDestroy()
     }
 

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterFragment.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterFragment.kt
@@ -3,6 +3,7 @@ package com.coreyhorn.mvpiframework.architecture
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.app.LoaderManager
+import android.view.View
 import com.coreyhorn.mvpiframework.basemodels.Action
 import com.coreyhorn.mvpiframework.basemodels.Event
 import com.coreyhorn.mvpiframework.basemodels.Result
@@ -16,25 +17,30 @@ abstract class PresenterFragment<E : Event, A : Action, R : Result, S : State> :
 
     override var presenter: Presenter<E, A, R, S>? = null
     override var disposables = CompositeDisposable()
-    override var attachAttempted = false
-    override var paused = true
+    override var attached = false
+    override var rootView: View? = null
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         initializePresenter(loaderManager)
     }
 
-    override fun onResume() {
-        super.onResume()
-        paused = false
-        setupViewBindings()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setView(view)
+        view.post {
+            setupViewBindings(view)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         attachStream()
     }
 
-    override fun onPause() {
-        paused = true
+    override fun onDestroy() {
         detachStream()
-        super.onPause()
+        super.onDestroy()
     }
 
     override fun initializeLoader(loaderCallbacks: LoaderManager.LoaderCallbacks<Presenter<E, A, R, S>>) {

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterLoader.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterLoader.kt
@@ -2,6 +2,7 @@ package com.coreyhorn.mvpiframework.architecture
 
 import android.content.Context
 import android.support.v4.content.Loader
+
 import com.coreyhorn.mvpiframework.basemodels.Action
 import com.coreyhorn.mvpiframework.basemodels.Event
 import com.coreyhorn.mvpiframework.basemodels.Result

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterView.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterView.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.support.v4.app.LoaderManager
 import android.support.v4.content.Loader
 import android.util.Log
+import android.view.View
 import com.coreyhorn.mvpiframework.LOGGING_TAG
 import com.coreyhorn.mvpiframework.MVPISettings
 import com.coreyhorn.mvpiframework.basemodels.Action
@@ -22,8 +23,9 @@ interface PresenterView<E : Event, A : Action, R : Result, S : State> {
 
     var presenter: Presenter<E, A, R, S>?
     var disposables: CompositeDisposable
-    var attachAttempted: Boolean
-    var paused: Boolean
+
+    var attached: Boolean
+    var rootView: View?
 
     val loaderCallbacks: LoaderManager.LoaderCallbacks<Presenter<E, A, R, S>>
         get() = object : LoaderManager.LoaderCallbacks<Presenter<E, A, R, S>> {
@@ -54,46 +56,51 @@ interface PresenterView<E : Event, A : Action, R : Result, S : State> {
     }
 
     fun attachStream() {
-        attachAttempted = true
-        presenter?.let {
-            it.attachEventStream(events)
-            it.states()
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe { state ->
-                        if (!paused) {
-                            renderViewState(state)
-                        }
-                    }
-                    .disposeWith(disposables)
-
-            events.doOnNext { event ->
-                if (MVPISettings.loggingEnabled) {
-                    Log.d(LOGGING_TAG, event.toString())
-                }
-            }
-            .subscribe()
-            .disposeWith(disposables)
-        }
+        attachIfReady()
     }
 
     fun detachStream() {
-        attachAttempted = false
         disposables.clear()
         disposables = CompositeDisposable()
         presenter?.detachEventStream()
         events = ReplaySubject.create()
+        attached = false
     }
 
     fun onPresenterAvailable(presenter: Presenter<E, A, R, S>) {
-        if (attachAttempted) {
-            attachStream()
-        }
+        this.presenter = presenter
+        attachIfReady()
     }
 
     fun initializeLoader(loaderCallbacks: LoaderManager.LoaderCallbacks<Presenter<E, A, R, S>>)
     fun getContext(): Context?
     fun loaderId(): Int
     fun presenterFactory(): PresenterFactory<Presenter<E, A, R, S>>
-    fun renderViewState(state: S)
-    fun setupViewBindings()
+    fun renderViewState(view: View, state: S)
+    fun setupViewBindings(view: View)
+
+    fun setView(view: View) {
+        rootView = view
+        attachIfReady()
+    }
+
+    private fun attachIfReady() {
+        if (readyToAttach()) {
+            disposables = CompositeDisposable()
+            presenter?.let {
+                it.attachEventStream(events)
+                it.states().observeOn(AndroidSchedulers.mainThread())
+                        .subscribe { state -> rootView?.let { view -> view.post { renderViewState(view, state) } } }
+                        .disposeWith(disposables)
+
+                events.doOnNext { event ->
+                    if (MVPISettings.loggingEnabled) {
+                        Log.d(LOGGING_TAG, event.toString())
+                    }}.subscribe().disposeWith(disposables)
+            }
+            attached = true
+        }
+    }
+
+    private fun readyToAttach(): Boolean = !attached && presenter != null && rootView != null
 }

--- a/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterView.kt
+++ b/mvpiframework/src/main/java/com/coreyhorn/mvpiframework/architecture/PresenterView.kt
@@ -86,11 +86,12 @@ interface PresenterView<E : Event, A : Action, R : Result, S : State> {
 
     private fun attachIfReady() {
         if (readyToAttach()) {
+            rootView?.let { it.post { setupViewBindings(it) }}
             disposables = CompositeDisposable()
             presenter?.let {
                 it.attachEventStream(events)
                 it.states().observeOn(AndroidSchedulers.mainThread())
-                        .subscribe { state -> rootView?.let { view -> view.post { renderViewState(view, state) } } }
+                        .subscribe { state -> rootView?.let { view -> view.post { if (attached) renderViewState(view, state) } } }
                         .disposeWith(disposables)
 
                 events.doOnNext { event ->


### PR DESCRIPTION
This change radically modifies the way the event and result streams are attached / detached from the view.

Also we now pass a non-null view into our renderViewState and setupViewBindings functions. This should allow null-safe access of already laid out views, preventing null pointers when accessing their children.